### PR TITLE
Add CI vulnerability scanning (#43)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Python dependencies (reads pyproject.toml / setup.py)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Docker base images (Dockerfiles in repo root)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,93 @@
+name: Security
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  schedule:
+    # Weekly scan to catch newly disclosed CVEs in unchanged dependencies
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Dependency vulnerability scan (PyPA pip-audit) — known CVEs in deps
+  # ---------------------------------------------------------------------------
+  pip-audit:
+    name: pip-audit (dependencies)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[ui-full]"
+
+      - name: Run pip-audit
+        uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          # Audit the installed environment so all extras are covered
+          local: true
+
+  # ---------------------------------------------------------------------------
+  # Static analysis (CodeQL) — vulnerabilities in our own Python code
+  # Results appear under the repo's Security > Code scanning tab.
+  # ---------------------------------------------------------------------------
+  codeql:
+    name: CodeQL (static analysis)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"
+
+  # ---------------------------------------------------------------------------
+  # Trivy filesystem scan — dependency + misconfiguration scan, uploads SARIF
+  # ---------------------------------------------------------------------------
+  trivy:
+    name: Trivy (filesystem)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-fs


### PR DESCRIPTION
Closes #43

## Summary
Adds automated dependency and code vulnerability scanning.

- **`.github/dependabot.yml`** — weekly update PRs for `pip`, `github-actions`, and `docker` ecosystems.
- **`.github/workflows/security.yml`** — runs on push/PR to `main`/`develop`, weekly cron, and manual dispatch:
  - **pip-audit** — known CVEs in installed dependencies (`[ui-full]` extras).
  - **CodeQL** — static analysis of project Python code (`security-extended`).
  - **Trivy** — filesystem dependency + misconfiguration scan; SARIF uploaded to the Security tab.

## Follow-up (manual, one-time)
- Enable Dependabot alerts/security updates under Settings → Code security.
- CodeQL/Trivy SARIF upload requires GitHub code scanning (free for public repos).