### PR TITLE
Add Codecov token and slug to coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,10 @@ jobs:
         run: |
           pytest tests/ -v --cov=src/prompt_assemble --cov-report=xml
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: HominemAI/prompt-assemble
           files: ./coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
Adds `token` and `slug` to the Codecov upload step in `test.yml`, and updates `codecov/codecov-action` to v5, so coverage uploads authenticate on internal (non-fork) PRs.

No application code changes — `pytest` already emits `coverage.xml` via `--cov-report=xml`.

## Required follow-up
- Add the `CODECOV_TOKEN` repository secret (Settings → Secrets and variables → Actions, or `gh secret set CODECOV_TOKEN`). Without it, uploads still won't authenticate on internal PRs.

## Note
- Supersedes #53 (which bumped codecov-action 3→7). This sets v5 per Codecov's recommended config; #53 can be closed.