### PR TITLE
Test on Python 3.13/3.14 and add matching classifiers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.11', '3.12' ]
+        python-version: [ '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing",
     "Typing :: Typed",


### PR DESCRIPTION
Now that the runtime image is on `python:3.14-slim` (#48), align CI and metadata:

- **`test.yml`** — add `3.13` and `3.14` to the test matrix so CI actually exercises the versions the image and packaging claim to support.
- **`pyproject.toml`** — add `Programming Language :: Python :: 3.13` and `:: 3.14` classifiers.

No source changes; the library already imports nothing removed in 3.12–3.14.