### PR TITLE
Add security policy (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,8 @@ Instead, report it privately in one of these two ways:
 
 - **On GitHub:** open the **Security** tab above and click
   **"Report a vulnerability."** This keeps everything private.
-- **By email:** write to **secobs@hominem.ai**.
+- **On the web:** use our security report form at
+  **https://hominem.ai/security**.
 
 ## First, a quick check
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+## Found a security problem? Please tell us privately.
+
+If you think you've found a security vulnerability in **prompt-assemble**,
+we'd really appreciate a heads-up — thank you for helping keep the project
+and its users safe.
+
+**Please don't open a public GitHub issue, discussion, or pull request for
+security problems.** Posting it publicly tells attackers about the issue
+before there's a fix.
+
+Instead, report it privately in one of these two ways:
+
+- **On GitHub:** open the **Security** tab above and click
+  **"Report a vulnerability."** This keeps everything private.
+- **By email:** write to **secobs@hominem.ai**.
+
+## First, a quick check
+
+Before reporting, please take a minute to see if it's already known:
+
+- Look at this repo's published **security advisories** (the **Security**
+  tab → **Advisories**) and any known **CVEs** for the project.
+- Check whether there's already an open report or pull request addressing it.
+
+If it's already been reported or fixed, you don't need to file it again. But
+if you have new details, we'd still love to hear them — just **reference the
+existing advisory, CVE, or pull request** so we can connect your notes to it.
+
+## What to tell us
+
+The more you can share, the faster we can fix it. If you can, include:
+
+- What the problem is, and what someone could do with it.
+- Step-by-step instructions (or a small proof-of-concept) to reproduce it.
+- Which version and setup you were using.
+- Any workaround you've already found.
+
+Don't worry if you can't fill in everything — send us what you have.
+
+## Which versions we fix
+
+This project is still evolving quickly, so we only patch the **most recent
+release**. If you're on an older version, please update first — the problem
+may already be fixed.
+
+## What happens next
+
+We're a small team without dedicated security staff, so we can't promise
+specific response times. What we can say is this: we read every report, we
+take security seriously, and we'll look into confirmed problems and fix them
+as best we can. If we publish a fix, we're happy to credit you — or keep you
+anonymous if you'd prefer.
+
+All we ask in return is that you give us a reasonable amount of time to look
+into the problem before sharing it publicly.
+
+## Testing in good faith is welcome
+
+If you're researching security in good faith and following this policy,
+consider it authorized — we won't take legal action against you. If you're
+ever unsure whether something is okay, just ask us first.


### PR DESCRIPTION
Adds a plain-language SECURITY.md: private reporting via GitHub Private Vulnerability Reporting or secobs@hominem.ai, a duplicate/CVE check, what to include, and good-faith safe harbor. No response-time commitments (best-effort language for a small team).